### PR TITLE
Create a RxJournal specific directory + clearCache only deletes .cq4

### DIFF
--- a/src/main/java/org/rxjournal/impl/RxJournal.java
+++ b/src/main/java/org/rxjournal/impl/RxJournal.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -23,11 +24,40 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class RxJournal {
     private static final Logger LOG = LoggerFactory.getLogger(RxJournal.class.getName());
+
+    /**
+     * The default name for the data directory.
+     */
+    public static final String RXJOURNAL_DIRNAME = ".rxJournal";
+
     private String dir;
     private final AtomicLong messageCounter = new AtomicLong(0);
 
-    public RxJournal(String dir){
-        this.dir = dir;
+    /**
+     * Create an {@link RxJournal} that will store or read its data from the {@value RXJOURNAL_DIRNAME} directory
+     * inside the given {@literal baseDir}. Use {@link #getDir()} to obtain the full path of said directory, and
+     * {@link #clearCache()} to clean that directory of RxJournal-specific files.
+     *
+     * @param baseDir the base directory into which the RxJournal will create a RxJournal-dedicated data directory {@value RXJOURNAL_DIRNAME}.
+     * @see #getDir()
+     * @see #clearCache()
+     */
+    public RxJournal(String baseDir){
+        this.dir = Paths.get(baseDir, RXJOURNAL_DIRNAME).toString();
+    }
+
+    /**
+     * Create an {@link RxJournal} that will store or read its data from the {@literal journalName} directory
+     * inside the given {@literal baseDir}. Use {@link #getDir()} to obtain the full path of said directory, and
+     * {@link #clearCache()} to clean that directory of RxJournal-specific files.
+     *
+     * @param baseDir the base directory into which the RxJournal will create a RxJournal-dedicated data directory.
+     * @param journalName the name to use for this RxJournal's data directory, instead of the default {@value RXJOURNAL_DIRNAME}.
+     * @see #getDir()
+     * @see #clearCache()
+     */
+    public RxJournal(String baseDir, String journalName){
+        this.dir = Paths.get(baseDir, journalName).toString();
     }
 
     public RxRecorder createRxRecorder(){
@@ -42,14 +72,39 @@ public class RxJournal {
         return new RxValidator();
     }
 
+    /**
+     * Return the path to the RxJournal-specific directory used to store binary representation of the journal on disk.
+     * This directory is one level deeper than the base directory initially passed to RxJournal's
+     * {@link RxJournal#RxJournal(String) constructor}.
+     *
+     * @return the path to the RxJournal specific directory.
+     */
+    public String getDir() {
+        return dir;
+    }
+
+    /**
+     * Clear this RxJournal's {@link #getDir() data directory} from RxJournal-specific binary files, and remove it as
+     * well (but only if it has become empty). If other files have been created inside the data directory, it is the
+     * responsibility of the user to delete them AND the data directory.
+     *
+     * @throws IOException in case of directory traversal or file deletion problems
+     */
     public void clearCache() throws IOException {
         LOG.info("Deleting existing recording [{}]", dir);
-        if(Files.exists(Paths.get(dir))) {
-            Files.walk(Paths.get(dir))
+        Path journalDir = Paths.get(dir);
+        if(Files.exists(journalDir)) {
+            Files.walk(journalDir)
                     .map(Path::toFile)
-                    .sorted((o1, o2) -> -o1.compareTo(o2))
+                    .filter(f -> f.isFile() && f.getName().endsWith(".cq4"))
+                    .peek(f -> LOG.info("Removing {}", f.getName()))
                     .forEach(File::delete);
-            Files.deleteIfExists(Paths.get(dir));
+
+            try {
+                Files.deleteIfExists(journalDir);
+            } catch (DirectoryNotEmptyException e) {
+                LOG.info("Directory does not only contain cq4 files, not deleted");
+            }
         }
     }
 

--- a/src/test/java/org/rxjournal/impl/RxJournalDirectoryTest.java
+++ b/src/test/java/org/rxjournal/impl/RxJournalDirectoryTest.java
@@ -1,0 +1,114 @@
+package org.rxjournal.impl;
+
+import io.reactivex.Flowable;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class RxJournalDirectoryTest {
+
+    Path base;
+    Path expectedDir;
+
+    @Before
+    public void createDir() throws IOException {
+        base = Files.createTempDirectory("RxJournal");
+        expectedDir = base.resolve(RxJournal.RXJOURNAL_DIRNAME);
+    }
+
+    @After
+    public void deleteDir() throws IOException {
+        if (Files.exists(expectedDir)) {
+            Files.walk(expectedDir)
+                    .map(Path::toFile)
+                    .filter(f -> f.isFile() && (
+                            f.getName().endsWith(".txt") || f.getName().endsWith(".cq4")))
+                    .peek(f -> System.out.println("will delete " + f))
+                    .forEach(File::delete);
+            Files.deleteIfExists(expectedDir);
+        }
+        Files.deleteIfExists(base);
+    }
+
+    @Test
+    public void rxJournalUsesDefaultSubDir() throws IOException {
+        RxJournal journal = new RxJournal(base.toString());
+
+        Assert.assertEquals(expectedDir.toString(), journal.getDir());
+    }
+
+    @Test
+    public void rxJournalUsesSpecificSubDirWhenNamed() throws IOException {
+        RxJournal journal = new RxJournal(base.toString(), "foo");
+
+        Assert.assertNotEquals(expectedDir.toString(), journal.getDir());
+        Assert.assertEquals(expectedDir.toString().replace(RxJournal.RXJOURNAL_DIRNAME, "foo"), journal.getDir());
+    }
+
+    @Test
+    public void rxJournalDoesntCreateDir() {
+        RxJournal journal = new RxJournal(base.toString());
+
+        Assert.assertFalse(Files.exists(expectedDir));
+    }
+
+    @Test
+    public void rxJournalCreatesDirOnRecording() throws IOException {
+        RxJournal journal = new RxJournal(base.toString());
+        RxRecorder recorder = journal.createRxRecorder();
+
+        Assert.assertFalse(Files.exists(expectedDir));
+
+        recorder.record(Flowable.just("foo"), "");
+        Assert.assertTrue(Files.exists(expectedDir));
+    }
+
+    @Test
+    public void rxJournalClearsIfOnlyCq4Files() throws IOException {
+        RxJournal journal = new RxJournal(base.toString());
+
+        RxRecorder recorder = journal.createRxRecorder();
+        recorder.record(Flowable.just("foo"), "");
+        Assert.assertTrue(Files.exists(expectedDir));
+
+        //short circuit the test if the dir is unexpected, just in case the clearCache would then be too destructive
+        Assert.assertEquals(expectedDir.toString(), journal.getDir());
+
+        journal.clearCache();
+
+        Assert.assertFalse(Files.exists(expectedDir));
+    }
+
+    @Test
+    public void rxJournalClearsOnlyCq4FilesAndKeepsBaseDir() throws IOException {
+        Files.createDirectories(expectedDir);
+        Path tempFile = Files.createTempFile(expectedDir, "rxJournalClearsOnlyCq4", ".txt");
+
+        RxJournal journal = new RxJournal(base.toString());
+
+        RxRecorder recorder = journal.createRxRecorder();
+        recorder.record(Flowable.just("foo"), "");
+
+        //short circuit the test if the dir is unexpected, just in case the clearCache would then be too destructive
+        Assert.assertEquals(expectedDir.toString(), journal.getDir());
+
+        journal.clearCache();
+
+        Assert.assertTrue(Files.exists(expectedDir));
+        Assert.assertTrue(Files.exists(tempFile));
+
+        long count = Files.walk(expectedDir, 1)
+                .map(Path::toFile)
+                .filter(File::isFile)
+                .count();
+
+        Assert.assertEquals(1, count);
+    }
+
+}


### PR DESCRIPTION
This commit limits the destructive potential of clearCache by
 - using the directory from the constructor as a base directory, and
   creating a specific directory inside it for ChronicleQueue files
 - limiting the deletion done by `clearCache` to .cq4 files inside that
    directory (just in case some other files have been created manually
    there)

Fixes #2